### PR TITLE
Better reporting of command failures

### DIFF
--- a/dephell_setuptools/_cmd.py
+++ b/dephell_setuptools/_cmd.py
@@ -61,8 +61,11 @@ class CommandReader(BaseReader):
                 )
             if result.returncode != 0:
                 raise RuntimeError('Command {!r} failed in {} with RC={}: {}'.format(
-                    cmd, os.getcwd(), result.returncode,
-                    result.stderr.decode('utf-8').strip().split('\n')[-1]))
+                    cmd,
+                    os.getcwd(),
+                    result.returncode,
+                    result.stderr.decode('utf-8').strip().split('\n')[-1],
+                ))
 
             with output_json.open() as stream:
                 content = json.load(stream)

--- a/dephell_setuptools/_cmd.py
+++ b/dephell_setuptools/_cmd.py
@@ -60,7 +60,9 @@ class CommandReader(BaseReader):
                     env=env,
                 )
             if result.returncode != 0:
-                raise RuntimeError(result.stderr.decode().strip().split('\n')[-1])
+                raise RuntimeError('Command {!r} failed in {} with RC={}: {}'.format(
+                    cmd, os.getcwd(), result.returncode,
+                    result.stderr.decode('utf-8').strip().split('\n')[-1]))
 
             with output_json.open() as stream:
                 content = json.load(stream)


### PR DESCRIPTION
If you get an error, you can start guessing what command failed. This makes that explicit.

Also, assuming UTF8 is way better than assuming ASCII.