### PR TITLE
Fix compatibility with setuptools>=61.0.0

### DIFF
--- a/dephell_setuptools/_cfg.py
+++ b/dephell_setuptools/_cfg.py
@@ -5,7 +5,12 @@ from pathlib import Path
 from typing import Any, Dict, Union
 
 # external
-from setuptools.config import ConfigMetadataHandler, ConfigOptionsHandler
+try:
+    from setuptools.config import ConfigMetadataHandler, ConfigOptionsHandler
+except ImportError:
+    # In setuptools v61.0.0, everything was moved to setuptools.config.setupcfg.
+    # see https://github.com/pypa/setuptools/commit/49b7a60050836868ecd63dc38ad0729626a356f3
+    from setuptools.config.setupcfg import ConfigMetadataHandler, ConfigOptionsHandler
 
 # app
 from ._base import BaseReader


### PR DESCRIPTION
In setuptools v61.0.0, `setuptools.config` was moved to `setuptools.config.setupcfg`.
There is no mention of this breaking change in the [CHANGES.rst](https://github.com/pypa/setuptools/blob/ec2d4e92cf66805b48a8868b00102555f7f46c8e/CHANGES.rst#v6100) but here is [the corresponding commit](https://github.com/pypa/setuptools/commit/49b7a60050836868ecd63dc38ad0729626a356f3)